### PR TITLE
Make packaging independent from grafov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 M3U8 [![](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go#video)
 ====
 
+**This fork has ben made self-contained at edgeware/m3u8. It is now independendent of grafov/m3u8. grafov licensing and copyright still applies.**
+
 This is the most complete opensource library for parsing and generating of M3U8 playlists
 used in HTTP Live Streaming (Apple HLS) for internet video translations.
 

--- a/example/example.go
+++ b/example/example.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/grafov/m3u8"
-	"github.com/grafov/m3u8/example/template"
+	"github.com/edgeware/m3u8"
+	"github.com/edgeware/m3u8/example/template"
 )
 
 func main() {
@@ -16,7 +16,7 @@ func main() {
 		panic("$GOPATH is empty")
 	}
 
-	m3u8File := "github.com/grafov/m3u8/sample-playlists/media-playlist-with-custom-tags.m3u8"
+	m3u8File := "github.com/edgeware/m3u8/sample-playlists/media-playlist-with-custom-tags.m3u8"
 	f, err := os.Open(path.Join(GOPATH, "src", m3u8File))
 	if err != nil {
 		panic(err)

--- a/example/template/custom-playlist-tag-template.go
+++ b/example/template/custom-playlist-tag-template.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/grafov/m3u8"
+	"github.com/edgeware/m3u8"
 )
 
 // #CUSTOM-PLAYLIST-TAG:<number>

--- a/example/template/custom-segment-tag-template.go
+++ b/example/template/custom-segment-tag-template.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/grafov/m3u8"
+	"github.com/edgeware/m3u8"
 )
 
 // #CUSTOM-SEGMENT-TAG:<attribute-list>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/grafov/m3u8
+module github.com/edgeware/m3u8
 
 go 1.12


### PR DESCRIPTION
repo was forked from github.com/grafov/m3u8
it is now independent as github.com/edgeware/m3u8

This to allow sgbo import github.com/edgeware/m3u8

I do not know what more files to change for the sbgo-import. Examples still import grafov, that needs to be changed at some point in time too