### PR TITLE
Parse INSTREAM-ID in Alternative

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -335,6 +335,8 @@ func decodeLineOfMasterPlaylist(p *MasterPlaylist, state *decodingState, line st
 					return fmt.Errorf("non-integer value %q for CHANNELS attribute", v)
 				}
 				alt.Channels = uint(channels)
+			case "INSTREAM-ID":
+				alt.InstreamID = v
 			}
 		}
 		state.alternatives = append(state.alternatives, &alt)

--- a/structure.go
+++ b/structure.go
@@ -198,6 +198,7 @@ type Alternative struct {
 	Characteristics string
 	Subtitles       string
 	Channels        uint
+	InstreamID      string
 }
 
 // MediaSegment structure represents a media segment included in a


### PR DESCRIPTION
Instream-ID (from HLS v6) is needed for making CEA608 info.